### PR TITLE
fix: remove call to undefined set_term_order causing fatal on term save

### DIFF
--- a/classes/class-bsf-changelog-post-type.php
+++ b/classes/class-bsf-changelog-post-type.php
@@ -70,8 +70,6 @@ class BSF_Changelog_Post_Type {
 				}
 			}
 		}
-
-		$this->set_term_order( $term_id, $tt_id );
 	}
 
 	/**


### PR DESCRIPTION
## What
Removes `$this->set_term_order( $term_id, $tt_id );` from the static method `save_category_meta()` in `classes/class-bsf-changelog-post-type.php`.

## Why
Two problems with this line:
1. `$this` is used inside a **static** method — PHP throws `Error: Using $this when not in object context`, a fatal error every time an admin creates a new Product term.
2. `set_term_order()` is not defined anywhere in the codebase, so even a `self::` call would fatal.

Targets the `sub-versioning` branch so the fix lands inside PR #30 before it merges to master.