### PR TITLE
feat: sub versioning support with redesigned changelog layout

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,6 +27,60 @@ module.exports = function( grunt ) {
 			},
 		},
 
+		copy: {
+			main: {
+				options: {
+					mode: true,
+				},
+				src: [
+					'**',
+					'!node_modules/**',
+					'!.vscode/**',
+					'!build/**',
+					'!css/sourcemap/**',
+					'!.git/**',
+					'!bin/**',
+					'!.gitlab-ci.yml',
+					'!bin/**',
+					'!tests/**',
+					'!phpunit.xml.dist',
+					'!*.sh',
+					'!*.map',
+					'!*.zip',
+					'!Gruntfile.js',
+					'!package.json',
+					'!.gitignore',
+					'!phpunit.xml',
+					'!README.md',
+					'!sass/**',
+					'!codesniffer.ruleset.xml',
+					'!vendor/**',
+					'!composer.json',
+					'!composer.lock',
+					'!package-lock.json',
+					'!phpcs.xml.dist',
+				],
+				dest: 'bsf-changelog/',
+			},
+		},
+		compress: {
+			main: {
+				options: {
+					archive: 'bsf-changelog-<%= pkg.version %>.zip',
+					mode: 'zip',
+				},
+				files: [
+					{
+						src: [ './bsf-changelog/**' ],
+					},
+				],
+			},
+		},
+		clean: {
+			main: [ 'bsf-changelog' ],
+			zip: [ '*.zip' ],
+		},
+
 		makepot: {
 			target: {
 				options: {
@@ -44,10 +98,19 @@ module.exports = function( grunt ) {
 		},
 	} );
 
+	grunt.loadNpmTasks( 'grunt-contrib-copy' );
+	grunt.loadNpmTasks( 'grunt-contrib-compress' );
+	grunt.loadNpmTasks( 'grunt-contrib-clean' );
 	grunt.loadNpmTasks( 'grunt-wp-i18n' );
 	grunt.loadNpmTasks( 'grunt-wp-readme-to-markdown' );
 	grunt.registerTask( 'i18n', ['addtextdomain', 'makepot'] );
 	grunt.registerTask( 'readme', ['wp_readme_to_markdown'] );
+	grunt.registerTask( 'release', [
+		'clean:zip',
+		'copy',
+		'compress',
+		'clean:main',
+	] );
 
 	grunt.util.linefeed = '\n';
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # BSF Changelog #
-**Contributors:** [pratikchaskar](https://profiles.wordpress.org/pratikchaskar/)
-**Tags:** changelog, wpchangelog, products-changelog,
-**Requires at least:** 3.0
-**Tested up to:** 6.5
-**Stable tag:** 1.0.6
-**License:** GPLv2 or later
-**License URI:** http://www.gnu.org/licenses/gpl-2.0.html
+**Contributors:** [pratikchaskar](https://profiles.wordpress.org/pratikchaskar/)  
+**Tags:** changelog, wpchangelog, products-changelog,  
+**Requires at least:** 3.0  
+**Tested up to:** 6.5  
+**Stable tag:** 1.0.7  
+**License:** GPLv2 or later  
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
 BSF Changelog allows you to create Changelog website within minute with custom layouts.
 

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1,4 +1,8 @@
-.clearfix:before, 
+html {
+	scroll-behavior: smooth;
+}
+
+.clearfix:before,
 .clearfix:after {
     display: table;
     content: "";
@@ -7,8 +11,6 @@
 .clearfix:after {
     clear: both;
 }
-
-*, *:before, *:after {box-sizing:  border-box !important;}
 
 @font-face {
   font-family: 'changelog';
@@ -143,15 +145,115 @@
     position: relative;
     margin: 0;
  }
- .bsf-main-wrap article {
+ .bsf-main-wrap .type-chnangelogs {
      border-bottom: none;
      margin: 0 !important;
  }
- .bsf-main-wrap article i {
+ .bsf-main-wrap .type-chnangelogs i {
      font-size: inherit;
      line-height: inherit;
      margin-right: 10px;
  }
+
+
+/* Changelog Pre-Title */
+
+.pre-title {
+	display: flex;
+	margin-bottom: 16px;
+}
+
+.type-chnangelogs .entry-title {
+	display: inline;
+	font-size: 24px;
+}
+.type-chnangelogs .dashicons-paperclip:before {
+	font-size: 20px;
+	vertical-align: middle;
+}
+.type-chnangelogs .dashicons-paperclip {
+	margin-right: 5px;
+}
+.pre-title .author-img-section,
+.pre-title .author-name-date-section,
+.pre-title .category-section {
+	display: inline-block;
+}
+
+.img-name-date-section {
+	display: flex;
+	width: -webkit-fill-available;
+}
+
+.pre-title .author-img-section {
+	align-self: center;
+	height: 40px;
+	width: 40px;
+}
+
+.pre-title .author-img-section img {
+	height: 100%;
+	width: 100%;
+	border-radius: 50px;
+}
+
+.pre-title .author-name-date-section {
+	width: auto;
+	margin-left: 10px;
+}
+
+.pre-title .category-section {
+	align-self: center;
+	padding: 3px 10px;
+	border-radius: 20px;
+	background-color: #F9F5FF;
+	width: auto;
+	flex: none;
+}
+
+.pre-title .category-section .category-name {
+	color: var(--ast-global-color-0);
+    font-weight: 500;
+	font-size: 14px;
+}
+
+.pre-title .author-name-date-section .author-name {
+	font-weight: 500;
+	font-size: 14px;
+	margin-bottom: -8px;
+}
+
+.pre-title .author-name-date-section .publish-date {
+	color: #808080;
+	font-size: 14px;
+}
+
+.bsf-version-tag {
+	align-self: center;
+    border-radius: 20px;
+    width: auto;
+    flex: none;
+    line-height: 1em;
+    margin-left: 10px;
+    padding: 5px 10px;
+    display: inline-block;
+    background-color: var(--ast-global-color-0);
+}
+
+.bsf-version-no {
+	color: #ffffff;
+	font-size: 14px;
+}
+
+.see-more-text {
+	font-weight: 600;
+	cursor: pointer;
+	font-size: 16px;
+}
+
+.content-closed p:last-of-type {
+	margin-bottom: 0px;
+}
 
 /* Changelog Title */
 
@@ -241,20 +343,25 @@ h2.changelog-title:after {
 }
 
 .bsf-entry-content.clear {
+	font-size: 16px;
     width: 100%;
     height: auto;
     overflow: auto;
     visibility: visible;
 }
 
+.bsf-entry-content.content-closed.clear p:last-child {
+	margin-bottom: 0px;
+	display: inline;
+}
+
  /* Changelog Style */
 
  div#bsf-changelog-primary {
-    margin: 5em 0 !important;
+    margin: 2em 0 !important;
     padding: 0;
  }
  .product-tax-enabled .bsfc-archive-description,
- .post-type-archive-changelog .bsfc-archive-description, 
  .post-type-archive-changelog .bsfc-author-box,
  .product-tax-enabled .bsfc-author-box {
     background-color: #eee;
@@ -262,12 +369,23 @@ h2.changelog-title:after {
     padding: 5em 6.67em;
     border: 1px solid #e8e8e8;
  }
- body.product-tax-enabled article,
- body.post-type-archive-changelog article {
+ body.product-tax-enabled .type-chnangelogs,
+ body.post-type-archive-changelog .type-chnangelogs {
     background-color: #fff;
-    border-bottom: 1px solid #eee;
-    margin: 0;
-    padding: 5.34em 6.67em;
+    border-bottom: 2px solid #DADEE0;
+    margin: 2em 0 0 0;
+	padding: 2em;
+}
+body.product-tax-enabled .type-chnangelogs:has(.bsf-changelog-post-wrapper),
+body.post-type-archive-changelog .type-chnangelogs:has(.bsf-changelog-post-wrapper) {
+    padding: 0;
+}
+.bsf-changelog-post-wrapper {
+    padding: 40px;
+	background: #fff;
+}
+.bsf-changelog-img {
+	margin-top: 16px;
 }
 /* Pagination */
 .product-tax-enabled .nav-links {
@@ -277,23 +395,65 @@ h2.changelog-title:after {
     padding: 6px;
     border: 1px solid #d2d2d2;
 }
-.product-tax-enabled .entry-header,
-.single-product-enabled .entry-header {
-    margin-bottom: 2em !important;
+
+.bsf-pagination {
+	text-align: center;
 }
+
+.bsf-infinite-scroll .bsf-pagination {
+	display: none;
+}
+
+.bsf-pagination-infinite {
+	text-align: center;
+	margin: 2.5em 0 0;
+  }
+  .bsf-loader {
+	display: none;
+	margin: 0 auto;
+	min-height: 58px;
+	line-height: 58px;
+	width: 70px;
+	text-align: center;
+  }
+
+  .bsf-loader > div {
+	width: 18px;
+	height: 18px;
+	background-color: var(--ast-global-color-0);
+	border-radius: 100%;
+	display: inline-block;
+	animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+  }
+
+  .bsf-loader .bsf-loader-1 {
+	animation-delay: -0.32s;
+  }
+
+  .bsf-loader .bsf-loader-2 {
+	animation-delay: -0.16s;
+  }
+
+  @keyframes sk-bouncedelay {
+	0%,
+	80%,
+	100% {
+	  transform: scale(0);
+	}
+	40% {
+	  transform: scale(1);
+	}
+  }
 
 @media (max-width: 768px ) {
     .bsf-changelog-cat-wrap .bsf-changelog-col {
         float: none;
         width: 100%;
     }
-    .product-tax-enabled .bsfc-archive-description, 
-    .post-type-archive-changelog .bsfc-archive-description, 
-    .post-type-archive-changelog .bsfc-author-box, 
+    .product-tax-enabled .bsfc-archive-description,
+    .post-type-archive-changelog .bsfc-archive-description,
+    .post-type-archive-changelog .bsfc-author-box,
     .product-tax-enabled .bsfc-author-box {
-        padding: 2em;
-    }
-    body.product-tax-enabled article, body.post-type-archive-changelog article {
         padding: 2em;
     }
     .bsf-changelog-col:after {
@@ -305,4 +465,82 @@ h2.changelog-title:after {
     .bsf-changelog-cat-wrap {
         margin: 35px 0;
     }
+	span.bsf-sub-version-date {
+		position: relative;
+		top: 0;
+		left: 0;
+		right: 0;
+	}
+}
+
+/* Changelog Sub version CSS */
+.bsf-sub-versions-list {
+    padding: 0 40px;
+    background: #F9FAFB;
+    display: none;
+    border-top: none;
+    border-radius: 0 0 6px 6px;
+}
+.show-list .bsf-sub-versions-list {
+    display: block;
+}
+.bsf-sub-versions-title {
+    line-height: 20px;
+    padding: 16px 40px;
+    font-size: 0.9em;
+    background: #F9FAFB;
+    cursor: pointer;
+    border-radius: 0 0 6px 6px;
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+    align-content: center;
+    align-items: center;
+}
+.ast-subver-title {
+	font-weight: 600;
+    color: #475569;
+    font-size: 16px;
+    line-height: 28px;
+}
+.ast-subver-svg {
+	fill: #4B5563;
+    width: 12px;
+    margin-top: 4px;
+}
+.show-list .ast-subver-svg {
+    transform: rotate(180deg);
+}
+.bsf-sub-version-date {
+    position: absolute;
+    right: 0;
+    top: 40px;
+    font-size: 0.8em;
+}
+.bsf-subversion-item {
+    position: relative;
+	padding: 40px 0;
+}
+
+.bsf-sub-version-content > :last-child {
+    margin-bottom: 0;
+    padding-bottom: 0;
+}
+
+.bsf-subversion-item .bsf-sub-version-title {
+    padding-top: 0 !important;
+    margin: 0 !important;
+    position: relative;
+}
+
+.bsf-sub-versions-list .bsf-subversion-item {
+    border-bottom: 1px solid #E2E8F0;
+}
+
+.bsf-sub-version-content p {
+    margin-bottom: 1em;
+}
+
+.bsf-sub-version-content {
+    margin-top: 24px;
 }

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,0 +1,135 @@
+(function($) {
+	$( '.see-more-text' ).click( function() {
+		post_id = ( $(this).closest('.type-chnangelogs') ).attr('id');
+		seeMore(post_id);
+	});
+
+	$(document).on('click', '.bsf-sub-versions-title', function() {
+		let self = $(this);
+		if ( self.closest('.bsf-sub-versions-wrapper').hasClass('show-list') ) {
+			self.closest('.bsf-sub-versions-wrapper').removeClass('show-list');
+			self.find('.ast-subver-title').text( bsf_pagination.show_subversion_text );
+		} else {
+			self.closest('.bsf-sub-versions-wrapper').addClass('show-list');
+			self.find('.ast-subver-title').text( bsf_pagination.hide_subversion_text );
+		}
+	});
+
+	function seeMore(post_id){
+		$( '#' + post_id + ' .bsf-entry-content.content-open' ).css('height', 'auto').show();
+		$( '#' + post_id + ' .bsf-entry-content.content-closed' ).hide();
+		$( '#' + post_id + ' .see-more-text' ).hide();
+		if ( $( '#' + post_id + ' .bsf-changelog-img' ).hasClass( 'bsf-featured-img-hide' ) ) {
+			$( '#' + post_id + ' .bsf-changelog-img' ).hide();
+		}
+	}
+
+	var pattern = new RegExp('^[\\w\\-]+$');
+	var id = window.location.hash.substring(1);
+	if ( pattern.test( id ) ) {
+    	var targetElement = document.getElementById(id);
+		var offsetValue = targetElement.offsetTop;
+		if (targetElement.length) {
+			$('html,body').animate({
+				scrollTop: offsetValue
+			}, 1000);
+			return false;
+		}
+	}
+
+	const anchorLinks = document.querySelectorAll('a[href^="#"]:not(.uagb-tabs-list)');
+
+	anchorLinks.forEach(anchorLink => {
+		anchorLink.addEventListener('click', event => {
+    		event.preventDefault();
+
+    		const targetId = anchorLink.getAttribute('href').slice(1);
+
+			// Update the URL with the hash value and offset value
+			window.location.hash = targetId;
+  		});
+	});
+
+	var is_scroll = $('.bsf-infinite-scroll');
+	if( 0 != is_scroll.length ) {
+		var mainSelector = $('#main');
+		var rect = mainSelector[0].getBoundingClientRect();
+		var loadStatus = true;
+		var total = parseInt( bsf_pagination.infinite_total ) || '';
+		var count = parseInt( bsf_pagination.infinite_count ) || '';
+		var bsfLoadMore	= $('.bsf-load-more');
+		var offset = {
+			top: rect.top + window.scrollY,
+			left: rect.left + window.scrollX,
+		};
+		if( bsfLoadMore ){
+			bsfLoadMore.removeClass('active');
+		}
+		if( mainSelector.find('.type-chnangelogs:last-child').length > 0 ) {
+			var windowHeight50 = window.outerHeight / 1.25;
+			$( window ).on('scroll', function() {
+				if( (window.scrollY + windowHeight50 ) >= ( offset.top ) ) {
+					if (count > total) {
+						return false;
+					} else {
+						//	Pause for the moment ( execute if post loaded )
+						if( loadStatus == true ) {
+							NextloadPosts(count);
+							count++;
+							loadStatus = false;
+						}
+					}
+				}
+			});
+		}
+	}
+
+	function NextloadPosts(pageNumber) {
+		var loader = $('.bsf-pagination-infinite .bsf-loader');
+		if( bsfLoadMore ){
+			bsfLoadMore.removeClass('active');
+		}
+		var pageUrlSelector = $('a.next.page-numbers');
+		var nextDestUrl = pageUrlSelector.attr('href');
+		loader.css( 'display', 'block' );
+
+		var request = new XMLHttpRequest();
+			request.open('GET', nextDestUrl, true);
+			request.send();
+			request.onload = function() {
+				var string = request.response;
+				var data = new DOMParser().parseFromString(string, 'text/html');
+				var boxes = data.querySelectorAll( 'div.type-chnangelogs' );
+
+				//	Disable loader
+				loader.css( 'display', 'none' );
+				if( bsfLoadMore ){
+					bsfLoadMore.addClass( 'active');
+				}
+
+				//	Append posts
+				for (var boxCount = 0; boxCount < boxes.length; boxCount++) {
+					$('#main').append(boxes[boxCount]);
+				}
+
+				//	Add grid classes
+				var msg = 'No more Posts to show.';
+				//	Show no more post message
+				if( count > total ) {
+					$('.bsf-pagination-infinite').innerHTML = '<span class="bsf-load-more no-more active" style="display: inline-block;">' + msg + "</span>";
+				} else {
+					var pageUrlSelector = document.querySelector('a.next.page-numbers');
+					var newNextTargetUrl = nextDestUrl.replace(/\/page\/[0-9]+/, '/page/' + (pageNumber + 1));
+					pageUrlSelector.setAttribute('href', newNextTargetUrl);
+				}
+
+				$( '.see-more-text' ).click( function() {
+					post_id = ( $(this).closest('.type-chnangelogs') ).attr('id');
+					seeMore(post_id);
+				});
+
+				//	Complete the process 'loadStatus'
+				loadStatus = true;
+			}
+	}
+})(jQuery);

--- a/bsf-changelog.php
+++ b/bsf-changelog.php
@@ -5,7 +5,7 @@
  * Author: Pratik Chaskar
  * Author URI: https://pratikchaskar.com
  * Contributors: brainstormforce, Anil
- * Version: 1.0.6
+ * Version: 1.0.7
  * Description: BSF Changelog plugin is used for building multi products changelog website within minute, This plugin provides shortcodes to display changelog versions list and custom designs.
  * Text Domain: bsf-changelog
  *

--- a/classes/class-bsf-changelog-loader.php
+++ b/classes/class-bsf-changelog-loader.php
@@ -41,12 +41,11 @@ if ( ! class_exists( 'Bsf_Changelog_Loader' ) ) {
 		 */
 		private function __construct() {
 
-					// minimum requirement for PHP version.
+			// minimum requirement for PHP version.
 			$php = '5.4';
 
 			// If current version is less than minimum requirement, display admin notice.
 			if ( version_compare( PHP_VERSION, $php, '<' ) ) {
-
 				add_action( 'admin_notices', array( $this, 'php_version_notice' ) );
 				return;
 			}
@@ -79,6 +78,62 @@ if ( ! class_exists( 'Bsf_Changelog_Loader' ) ) {
 				add_filter( 'body_class', array( $this, 'bsf_single_product_body_class' ) );
 			}
 
+			add_action( 'bsf_changelog_after_version_content', array( $this, 'render_subversion_content' ) );
+		}
+
+		/**
+		 * Render subversion content where $post_id set as Post Parent to other posts.
+		 *
+		 * @param int $id Post ID.
+		 */
+		public function render_subversion_content( $post_id ) {
+			$bsf_changelog_expand_subversions_default = get_option( 'bsf_changelog_expand_subversions_default' );
+
+			$args = array(
+				'post_type'              => BSF_CHANGELOG_POST_TYPE,
+				'posts_per_page'         => -1,
+				'post_parent'            => get_the_ID(),
+				'update_post_meta_cache' => false,
+				'no_found_rows'          => true,
+				'post_status'            => 'publish',
+				'orderby'                => 'date',
+				'fields'                 => 'ids',
+				'order'                  => 'desc',
+				'nopaging'               => true,
+			);
+
+			$sub_versions_query = new WP_Query( $args );
+
+			if ( $sub_versions_query->have_posts() ) {
+				?>
+					<div class="bsf-sub-versions-wrapper <?php echo esc_attr( '1' === $bsf_changelog_expand_subversions_default || 'yes' === $bsf_changelog_expand_subversions_default ? 'show-list' : '' ); ?>">
+						<div class="bsf-sub-versions-list">
+							<?php
+								while ( $sub_versions_query->have_posts() ) {
+									$sub_versions_query->the_post();
+									$post_id    = get_the_ID();
+									$post_title = get_the_title();
+									?>
+										<div class="bsf-subversion-item">
+											<h4 class="bsf-sub-version-title"><?php echo esc_attr( $post_title ); ?></h4>
+											<span class="bsf-sub-version-date"> <?php echo get_the_date(); ?> </span>
+											<div class="bsf-sub-version-content"><?php echo do_shortcode( get_the_content() ); ?></div>
+										</div>
+									<?php
+								}
+							?>
+						</div>
+						<div class="bsf-sub-versions-title">
+							<span class="ast-subver-title"> <?php apply_filters( 'bsf_changelog_sub_version_show_text', _e( 'See More', 'bsf-changelog' ) ); ?> </span>
+							<span class="bsf-subver-toggle">
+								<svg class="ast-subver-svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" x="0px" y="0px" width="16px" height="16.043px" viewBox="57 35.171 26 16.043" enable-background="new 57 35.171 26 16.043" xml:space="preserve"> <path d="M57.5,38.193l12.5,12.5l12.5-12.5l-2.5-2.5l-10,10l-10-10L57.5,38.193z"></path>
+                				</svg>
+							</span>
+						</div>
+					</div>
+				<?php
+				wp_reset_postdata();
+			}
 		}
 
 		/**
@@ -176,8 +231,13 @@ if ( ! class_exists( 'Bsf_Changelog_Loader' ) ) {
 		function register_bsf_changelogs_plugin_settings() {
 			// Register our settings.
 			register_setting( 'bsf-changelogs-settings-group', 'bsf_changelog_category_template' );
+			register_setting( 'bsf-changelogs-settings-group', 'bsf_changelog_scroll_pagination' );
+			register_setting( 'bsf-changelogs-settings-group', 'bsf_changelog_hide_featured_img' );
+			register_setting( 'bsf-changelogs-settings-group', 'bsf_changelog_link_icon' );
+			register_setting( 'bsf-changelogs-settings-group', 'bsf_changelog_expand_subversions_default' );
 			register_setting( 'bsf-changelogs-settings-group', 'bsf_changelog_title' );
 			register_setting( 'bsf-changelogs-settings-group', 'bsf_changelog_sub_title' );
+			register_setting( 'bsf-changelogs-settings-group', 'bsf_changelog_default_raw_url' );
 		}
 
 		/**
@@ -276,7 +336,7 @@ if ( ! class_exists( 'Bsf_Changelog_Loader' ) ) {
 
 			$file = dirname( dirname( __FILE__ ) );
 
-			define( 'BSF_CHANGELOG_VERSION', '1.0.6' );
+			define( 'BSF_CHANGELOG_VERSION', '1.0.7' );
 			define( 'BSF_CHANGELOG_DIR_NAME', plugin_basename( $file ) );
 			define( 'BSF_CHANGELOG_BASE_FILE', trailingslashit( $file ) . BSF_CHANGELOG_DIR_NAME . '.php' );
 			define( 'BSF_CHANGELOG_BASE_DIR', plugin_dir_path( BSF_CHANGELOG_BASE_FILE ) );
@@ -296,6 +356,21 @@ if ( ! class_exists( 'Bsf_Changelog_Loader' ) ) {
 			require_once BSF_CHANGELOG_BASE_DIR . 'includes/bsf-changelog-shortcode.php';
 		}
 
+		static function shorten_text($text, $length) {
+			$text = preg_replace('/<!--(.|\s)*?-->/', '', $text);
+			if (strlen($text) <= $length) {
+				return $text;
+			}
+
+			$short_text = substr($text, 0, $length);
+
+			$short_text = force_balance_tags($short_text) . '<span class="see-more-text">...See more</span>';
+			$short_text = preg_replace('/<</', '<', $short_text);
+
+			return $short_text;
+		}
+
+
 		/**
 		 * Enqueue frontend scripts
 		 *
@@ -304,6 +379,18 @@ if ( ! class_exists( 'Bsf_Changelog_Loader' ) ) {
 		function enqueue_front_scripts() {
 			if ( is_post_type_archive( 'changelog' ) || is_tax( 'product' ) ) {
 				wp_enqueue_style( 'bsf-changelog-frontend-style', BSF_CHANGELOG_BASE_URL . 'assets/css/frontend.css' );
+				wp_enqueue_script( 'bsf-changelog-frontend-script', BSF_CHANGELOG_BASE_URL . 'assets/js/frontend.js', array( 'jquery' ), BSF_CHANGELOG_VERSION, true );
+				global $wp_query;
+				wp_localize_script(
+					'bsf-changelog-frontend-script',
+					'bsf_pagination',
+					array(
+						'infinite_count' => 2,
+						'hide_subversion_text' => apply_filters( 'bsf_changelog_sub_version_hide_text', __( 'Hide', 'bsf-changelog' ) ),
+						'show_subversion_text' => apply_filters( 'bsf_changelog_sub_version_show_text', __( 'See More', 'bsf-changelog' ) ),
+						'infinite_total' => $wp_query->max_num_pages,
+					)
+				);
 			}
 		}
 

--- a/classes/class-bsf-changelog-post-type.php
+++ b/classes/class-bsf-changelog-post-type.php
@@ -25,6 +25,86 @@ class BSF_Changelog_Post_Type {
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'register_taxonomies' ), 11 );
 		add_action( 'init', array( __CLASS__, 'register_post_types' ), 10 );
+		add_action( 'pre_get_posts', array( __CLASS__, 'update_changelog_list' ) );
+
+		add_action( 'product_add_form_fields', array( __CLASS__, 'add_form_fields' ), 10, 2 );
+		add_action( 'product_edit_form_fields', array( __CLASS__, 'edit_form_fields' ), 10, 2 );
+		add_action( 'created_product', array( __CLASS__, 'save_category_meta' ), 11, 2 );
+		add_action( 'edited_product', array( __CLASS__, 'updated_category_meta' ), 11, 2 );
+	}
+
+	/**
+	 * Add product category custom fields to add new screen.
+	 *
+	 * @since x.x.x
+	 * @param string $taxonomy to store taxonomy name.
+	 */
+	public static function add_form_fields( $taxonomy ) {
+		include_once BSF_CHANGELOG_BASE_DIR . 'includes/templates/add-category-meta.php';
+	}
+
+	/**
+	 * Add product category custom fields to edit screen.
+	 *
+	 * @since x.x.x
+	 * @param object $term to store term object.
+	 * @param string $taxonomy to store taxonomy name.
+	 */
+	public static function edit_form_fields( $term, $taxonomy ) {
+		$changelog_file_url = get_term_meta( $term->term_id, 'product_tax_changelog-file-url', true );
+		include_once BSF_CHANGELOG_BASE_DIR . 'includes/templates/edit-category-meta.php';
+	}
+
+	/**
+	 * Save docs category fields.
+	 *
+	 * @since x.x.x
+	 * @param int $term_id to store term id.
+	 */
+	public static function save_category_meta( $term_id, $tt_id ) {
+		if ( isset( $_POST['term_meta'] ) ) {
+			$cat_keys = array_keys( $_POST['term_meta'] );
+			foreach ( $cat_keys as $key ) {
+				if ( isset( $_POST['term_meta'][ $key ] ) ) {
+					add_term_meta( $term_id, "product_tax_$key", sanitize_text_field( $_POST['term_meta'][ $key ] ) );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Save docs category custom fields.
+	 *
+	 * @since x.x.x
+	 * @param int $term_id to store term id.
+	 */
+	public static function updated_category_meta( $term_id ) {
+		if ( isset( $_POST['term_meta'] ) ) {
+			$cat_keys = array_keys( $_POST['term_meta'] );
+			foreach ( $cat_keys as $key ) {
+				if ( isset( $_POST['term_meta'][ $key ] ) ) {
+					update_term_meta( $term_id, "product_tax_$key", $_POST['term_meta'][ $key ] );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Custom update posts list.
+	 *
+	 * @param object $query Query object.
+	 */
+	public static function update_changelog_list( $query ) {
+		// Check if we are on the edit.php page and it's the main query
+		if ( is_admin() && $query->is_main_query() && $query->get('post_type') === BSF_CHANGELOG_POST_TYPE ) {
+			$query->set('orderby', 'date');
+			$query->set('order', 'DESC');
+		}
+
+		// On frontend exclude posts which has post parent.
+		if ( ! is_admin() && ( is_tax( 'product' ) || is_post_type_archive( BSF_CHANGELOG_POST_TYPE ) ) && $query->is_main_query() ) {
+			$query->set( 'post_parent', 0 );
+		}
 	}
 
 	/**
@@ -124,6 +204,8 @@ class BSF_Changelog_Post_Type {
 			'excerpt',
 			'thumbnail',
 			'custom-fields',
+			'author',
+			'page-attributes',
 		);
 
 		$has_comments = get_option( 'bsf_search_has_comments' );
@@ -154,11 +236,12 @@ class BSF_Changelog_Post_Type {
 						'not_found'             => __( 'No version found', 'bsf-changelog' ),
 						'not_found_in_trash'    => __( 'No Version found in trash', 'bsf-changelog' ),
 						'parent'                => __( 'Parent Version', 'bsf-changelog' ),
-						'featured_image'        => __( 'changelogs image', 'bsf-changelog' ),
-						'set_featured_image'    => __( 'Set changelogs image', 'bsf-changelog' ),
+						'featured_image'        => __( 'Changelog Featured Image', 'bsf-changelog' ),
+						'set_featured_image'    => __( 'Set Changelog Featured Image', 'bsf-changelog' ),
 						'remove_featured_image' => __( 'Remove Version image', 'bsf-changelog' ),
 						'use_featured_image'    => __( 'Use as Version image', 'bsf-changelog' ),
 						'items_list'            => __( 'Version list', 'bsf-changelog' ),
+						'attributes' 		    => __( 'Version Attributes', 'bsf-changelog' ),
 					),
 					'description'         => __( 'This is where you can add new changelogs to your site.', 'bsf-changelog' ),
 					'public'              => true,
@@ -166,12 +249,13 @@ class BSF_Changelog_Post_Type {
 					'map_meta_cap'        => true,
 					'publicly_queryable'  => true,
 					'exclude_from_search' => false,
-					'hierarchical'        => false, // Hierarchical causes memory issues - WP loads all records!
+					'hierarchical'        => true, // Hierarchical causes memory issues - WP loads all records!
 					'query_var'           => true,
 					'supports'            => $supports,
-					'has_archive'         => true,
+					'has_archive'         => 'whats-new',
 					'show_in_nav_menus'   => true,
 					'show_in_rest'        => true,
+					'menu_icon'           => 'dashicons-list-view',
 				)
 			)
 		);

--- a/includes/bsf-archive-template.php
+++ b/includes/bsf-archive-template.php
@@ -6,19 +6,15 @@
  * @package Changelog/ArchiveTemplate
  */
 
-get_header();?>
+get_header();
+$bsf_changelog_scroll_pagination = get_option( 'bsf_changelog_scroll_pagination' );
+$page_class = isset( $bsf_changelog_scroll_pagination ) && '1' === $bsf_changelog_scroll_pagination || 'yes' === $bsf_changelog_scroll_pagination ? 'bsf-infinite-scroll' : '';
+$bsf_changelog_link_icon = get_option( 'bsf_changelog_link_icon' );
+$link_icon = isset( $bsf_changelog_link_icon ) && '1' === $bsf_changelog_link_icon || 'yes' === $bsf_changelog_link_icon ? '<i class="dashicons dashicons-paperclip"></i>' : '';
+$bsf_changelog_hide_featured_img = get_option( 'bsf_changelog_hide_featured_img' );
+$img_class = isset( $bsf_changelog_hide_featured_img ) && '1' === $bsf_changelog_hide_featured_img || 'yes' === $bsf_changelog_hide_featured_img ? 'bsf-featured-img-hide' : ''; ?>
 
-<?php $has_multiple_product = get_option( 'bsf_changelog_category_template' ); ?>
-<div class="wrap changelogs-archive-wraper">
-	<?php
-		// Display category list.
-	if ( ( '1' === $has_multiple_product || false === $has_multiple_product ) ) {
-		echo do_shortcode( '[changelog_product_list]' );
-	}
-	?>
-</div><!-- .wrap -->
-	<?php if ( ! ( '1' === $has_multiple_product || false === $has_multiple_product ) ) { ?>
-	<div class="wrap changelog-wraper">
+	<div class="wrap changelog-wraper <?php echo $page_class; ?>">
 		<div id="bsf-changelog-primary" class="content-area">
 			<main id="main" class="in-wrap" role="main">
 
@@ -54,31 +50,94 @@ get_header();?>
 					 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
 					 */
 					?>
-					<article id="post-<?php the_ID(); ?>" class="post-<?php the_ID(); ?> post type-chnangelogs status-publish format-standard chnangelogs_category">
-						<header class="entry-header">
-							<h2 class="entry-title"><?php the_title(); ?> </h2>
-							<div class="changelog-publish-date"><?php echo  get_the_date( 'j M Y' ); ?></div>
-						</header>
-						<div class="bsf-entry-content clear" itemprop="text">
-							<?php the_content(); ?>
+					<div id="post-<?php the_ID(); ?>" class="post-<?php the_ID(); ?> post type-chnangelogs status-publish format-standard chnangelogs_category">
+						<div class="bsf-changelog-post-wrapper">
+							<header class="entry-header">
+								<div class="pre-title" id="<?php echo ( sanitize_title( get_post_field( 'post_name', get_post() ) ) ); ?>">
+									<div class="img-name-date-section">
+									<div class="author-img-section">
+										<?php if ( get_avatar( get_the_author_meta('ID') ) ) {
+											echo get_avatar( get_the_author_meta('ID') );
+										} else { ?>
+											<img src="/images/no-image-default.jpg" />
+										<?php } ?>
+									</div>
+									<div class="author-name-date-section">
+										<div class="author-name"><?php the_author(); ?></div>
+										<div class="publish-date"><?php echo get_the_date(); ?></div>
+									</div>
+									<?php $tags = get_the_terms( get_the_ID(), 'changelog_tag' );
+									if ( $tags ) { ?>
+									<div class="bsf-version-tag">
+										<span class="bsf-version-no"><?php
+											echo $tags[0]->name;
+										?></span>
+									</div>
+									<?php } ?>
+									</div>
+									<?php $terms = wp_get_post_terms( get_the_ID(), 'product' );
+									if ( $terms ) { ?>
+									<div class="category-section">
+										<a href="<?php echo get_term_link( (int) $terms[0]->term_id ); ?>" class="category-name">
+										<?php
+											echo $terms[0]->name;
+										?>
+										</a>
+									</div>
+									<?php } ?>
+								</div>
+								<a href="#<?php echo ( sanitize_title( get_post_field( 'post_name', get_post() ) ) ); ?>"><?php echo $link_icon; ?><h2 class="entry-title"><?php the_title(); ?> </h2></a>
+							</header>
+							<?php
+							$img_pos = apply_filters( 'bsf_changelog_img_position_' . get_the_ID(), 'after' );
+							$img_pos_all = apply_filters( 'bsf_changelog_img_position_all', 'after' );
+							if ( ( 'before' === $img_pos || 'before' === $img_pos_all ) && has_post_thumbnail() ) { ?>
+								<div class="bsf-changelog-img <?php echo $img_class; ?>" style="margin-bottom: 16px;"><?php the_post_thumbnail( 'full' ); ?></div>
+							<?php }
+							do_action( 'bsf_changelog_before_content_' . get_the_ID() );
+							?>
+							<?php if ( has_excerpt() ) { ?>
+								<div class="bsf-entry-content content-closed clear" itemprop="text">
+								<?php the_excerpt(); ?>
+								</div>
+								<span class="see-more-text">Continue Reading...</span>
+							<?php } ?>
+							<?php $style = has_excerpt() ? 'style="display:none;"': ''; ?>
+							<div class="bsf-entry-content content-open clear" itemprop="text" <?php echo $style; ?>>
+								<?php the_content(); ?>
+							</div>
+							<?php do_action( 'bsf_changelog_after_content_' . get_the_ID() );
+							if ( ( 'after' === $img_pos || 'after' === $img_pos_all ) && ( 'before' !== $img_pos && 'before' !== $img_pos_all ) && has_post_thumbnail() ) { ?>
+								<div class="bsf-changelog-img <?php echo $img_class; ?>"><?php the_post_thumbnail( 'full' ); ?></div>
+							<?php }
+							?>
 						</div>
-					</article>
+						<?php do_action( 'bsf_changelog_after_version_content', get_the_ID() ); ?>
+					</div>
 					<?php
 				endwhile;
-				the_posts_pagination(
-					array(
-						'prev_text'          => '&laquo;<span class="screen-reader-text">' . __( 'Previous page', 'bsf-changelog' ) . '</span>',
-						'next_text'          => '<span class="screen-reader-text">' . __( 'Next page', 'bsf-changelog' ) . '</span>&raquo;',
-						'before_page_number' => '<span class="meta-nav screen-reader-text">' . __( 'Page', 'bsf-changelog' ) . ' </span>',
-					)
-				);
-
 			endif;
 			?>
 
 			</main><!-- #main -->
+			<div class='bsf-pagination'>
+		<?php the_posts_pagination(
+			array(
+				'prev_text'          => '&laquo;<span class="screen-reader-text">' . __( 'Previous page', 'bsf-changelog' ) . '</span>',
+				'next_text'          => '<span class="screen-reader-text">' . __( 'Next page', 'bsf-changelog' ) . '</span>&raquo;',
+			)
+		); ?>
+		</div>
+		<?php if ( isset( $bsf_changelog_scroll_pagination ) && '1' === $bsf_changelog_scroll_pagination || 'yes' === $bsf_changelog_scroll_pagination ) { ?>
+			<nav class="bsf-pagination-infinite">
+				<div class="bsf-loader">
+					<div class="bsf-loader-1"></div>
+					<div class="bsf-loader-2"></div>
+					<div class="bsf-loader-3"></div>
+				</div>
+			</nav>
+			<?php } ?>
 		</div><!-- #primary -->
 	</div><!-- .wrap -->
 		<?php
-	}
 	get_footer();

--- a/includes/bsf-changelog-options-page.php
+++ b/includes/bsf-changelog-options-page.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || die( 'No direct script access allowed!' );
 	<div class="bsf-options-form-wrap clearfix">
 
 		<h1><?php esc_html_e( 'Changelogs Settings', 'bsf-changelog' ); ?></h1>
-		<form method="post" action="options.php"> 
+		<form method="post" action="options.php">
 					<?php settings_fields( 'bsf-changelogs-settings-group' ); ?>
 					<?php do_settings_sections( 'bsf-changelogs-settings-group' ); ?>
 					<table  class="form-table">
@@ -29,7 +29,59 @@ defined( 'ABSPATH' ) || die( 'No direct script access allowed!' );
 								}
 								?>
 							</td>
-						</tr>	
+						</tr>
+						<tr valign="top">
+							<th scope="row"><?php _e( 'Enable Infinite Scroll pagination?', 'bsf-changelog' ); ?></th>
+							<td>
+								<?php
+								$bsf_changelog_scroll_pagination = get_option( 'bsf_changelog_scroll_pagination' );
+								if ( isset( $bsf_changelog_scroll_pagination ) && '1' === $bsf_changelog_scroll_pagination || 'yes' === $bsf_changelog_scroll_pagination ) {
+									echo '<input type="checkbox" checked name="bsf_changelog_scroll_pagination" value="1">';
+								} else {
+									echo '<input type="checkbox" name="bsf_changelog_scroll_pagination" value="1">';
+								}
+								?>
+							</td>
+						</tr>
+						<tr valign="top">
+							<th scope="row"><?php _e( 'Hide Featured Image when content is expanded?', 'bsf-changelog' ); ?></th>
+							<td>
+								<?php
+								$bsf_changelog_hide_featured_img = get_option( 'bsf_changelog_hide_featured_img' );
+								if ( isset( $bsf_changelog_hide_featured_img ) && '1' === $bsf_changelog_hide_featured_img || 'yes' === $bsf_changelog_hide_featured_img ) {
+									echo '<input type="checkbox" checked name="bsf_changelog_hide_featured_img" value="1">';
+								} else {
+									echo '<input type="checkbox" name="bsf_changelog_hide_featured_img" value="1">';
+								}
+								?>
+							</td>
+						</tr>
+						<tr valign="top">
+							<th scope="row"><?php _e( 'Enable link icon for Changelog title?', 'bsf-changelog' ); ?></th>
+							<td>
+								<?php
+								$bsf_changelog_link_icon = get_option( 'bsf_changelog_link_icon' );
+								if ( isset( $bsf_changelog_link_icon ) && '1' === $bsf_changelog_link_icon || 'yes' === $bsf_changelog_link_icon ) {
+									echo '<input type="checkbox" checked name="bsf_changelog_link_icon" value="1">';
+								} else {
+									echo '<input type="checkbox" name="bsf_changelog_link_icon" value="1">';
+								}
+								?>
+							</td>
+						</tr>
+						<tr valign="top">
+							<th scope="row"><?php _e( 'Expand sub versions by default?', 'bsf-changelog' ); ?></th>
+							<td>
+								<?php
+								$bsf_changelog_expand_subversions_default = get_option( 'bsf_changelog_expand_subversions_default' );
+								if ( isset( $bsf_changelog_expand_subversions_default ) && '1' === $bsf_changelog_expand_subversions_default || 'yes' === $bsf_changelog_expand_subversions_default ) {
+									echo '<input type="checkbox" checked name="bsf_changelog_expand_subversions_default" value="1">';
+								} else {
+									echo '<input type="checkbox" name="bsf_changelog_expand_subversions_default" value="1">';
+								}
+								?>
+							</td>
+						</tr>
 						<tr valign="top">
 							<th scope="row"><?php _e( 'Changelog Page Title', 'bsf-changelog' ); ?></th>
 							<td>
@@ -39,15 +91,27 @@ defined( 'ABSPATH' ) || die( 'No direct script access allowed!' );
 								?>
 								<input type="text" class="regular-text code" name="bsf_changelog_title" value="<?php echo get_option( 'bsf_changelog_title' ); ?> "/>
 							</td>
-						</tr>	
+						</tr>
 						<tr valign="top">
 							<th scope="row"><?php _e( 'Changelog Page Sub-Title', 'bsf-changelog' ); ?></th>
 							<td>
 								<input type="text" class="regular-text code" name="bsf_changelog_sub_title" value="<?php echo get_option( 'bsf_changelog_sub_title' ); ?> "/>
 							</td>
-						</tr>	
+						</tr>
+						<tr valign="top">
+							<th scope="row"><?php _e( 'Changelog Raw File URL', 'bsf-changelog' ); ?></th>
+							<td>
+								<input type="text" placeholder="https://raw.githubusercontent.com/brainstormforce/bsf-products/master/astra/changelog.txt" class="regular-text code" name="bsf_changelog_default_raw_url" value="<?php echo get_option( 'bsf_changelog_default_raw_url' ); ?>"/>
+								<p class="description"> <em>
+									<?php _e( 'This URL will be use to redirect users when click on "More Details".', 'bsf-changelog' ); ?>
+								</em> </p>
+								<p class="description"> <em>
+									<?php echo sprintf( '%s <a href="%s">%s</a> %s', __( 'For multiple products', 'bsf-changelog' ), esc_url( admin_url( '/edit-tags.php?taxonomy=product&post_type=' . BSF_CHANGELOG_POST_TYPE ) ), __( 'Edit Product category', 'bsf-changelog' ), __( '& provide link there.', 'bsf-changelog' ) ) ?>
+								</em> </p>
+							</td>
+						</tr>
 					</table>
-						<?php submit_button(); ?>
+				<?php submit_button(); ?>
 		</form>
 	</div>
 	<div class="bsf-shortcodes-wrap">
@@ -62,7 +126,7 @@ defined( 'ABSPATH' ) || die( 'No direct script access allowed!' );
 				<td>
 						<div class="bsf-shortcode-container wp-ui-text-highlight">
 							[changelog_product_list]
-						</div>  
+						</div>
 		</td>
 				</tr>
 			</table>

--- a/includes/bsf-changelog-shortcode.php
+++ b/includes/bsf-changelog-shortcode.php
@@ -39,6 +39,7 @@ function bsf_render_changelog_list( $atts, $content = null ) {
 	<?php
 		$changelog_title     = get_option( 'bsf_changelog_title' );
 		$changelog_sub_title = get_option( 'bsf_changelog_sub_title' );
+		$bsf_changelog_default_raw_url = get_option( 'bsf_changelog_default_raw_url' );
 
 	if ( '' !== $changelog_title ) {
 		echo '<h2 class="changelog-title">' . esc_attr( $changelog_title ) . '</h2>';

--- a/includes/changelog-taxonomy-template.php
+++ b/includes/changelog-taxonomy-template.php
@@ -10,23 +10,17 @@
  * @version 1.0
  */
 
-get_header(); ?>
-<div class="wrap changelog-wraper">
+get_header();
+$bsf_changelog_scroll_pagination = get_option( 'bsf_changelog_scroll_pagination' );
+$page_class = isset( $bsf_changelog_scroll_pagination ) && '1' === $bsf_changelog_scroll_pagination || 'yes' === $bsf_changelog_scroll_pagination ? 'bsf-infinite-scroll' : '';
+$bsf_changelog_link_icon = get_option( 'bsf_changelog_link_icon' );
+$link_icon = isset( $bsf_changelog_link_icon ) && '1' === $bsf_changelog_link_icon || 'yes' === $bsf_changelog_link_icon ? '<i class="dashicons dashicons-paperclip"></i>' : '';
+$bsf_changelog_hide_featured_img = get_option( 'bsf_changelog_hide_featured_img' );
+$img_class = isset( $bsf_changelog_hide_featured_img ) && '1' === $bsf_changelog_hide_featured_img || 'yes' === $bsf_changelog_hide_featured_img ? 'bsf-featured-img-hide' : ''; ?>
+
+<div class="wrap changelog-wraper <?php echo $page_class; ?>">
 	<div id="bsf-changelog-primary" class="content-area">
 		<main id="main" class="in-wrap" role="main">
-
-		<?php if ( have_posts() ) : ?>
-		<section class="bsfc-archive-description">
-			<div class="bsf-changelog-header">
-				<?php
-					$all_prodcut_url = site_url() . '/' . BSF_CHANGELOG_POST_TYPE;
-					echo '<h1 class="page-title">' . single_cat_title( '', false ) . '</h1>';
-				?>
-					<a href="<?php echo esc_url( $all_prodcut_url ); ?>"><?php _e( 'All Changelogs', 'bsf-changelog' ); ?></a> 
-					<?php echo '/ ' . single_cat_title( '', false ); ?>
-			</div><!-- .page-header -->
-		</section>
-	<?php endif; ?>
 
 		<?php
 		if ( have_posts() ) :
@@ -42,30 +36,76 @@ get_header(); ?>
 				 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
 				 */
 				?>
-				<article id="post-<?php the_ID(); ?>" class="post-<?php the_ID(); ?> post type-chnangelogs status-publish format-standard chnangelogs_category">
-					<header class="entry-header">
-						<h2 class="entry-title"><?php the_title(); ?> </h2>
-						<div class="changelog-publish-date"><?php echo  get_the_date( 'j M Y' ); ?></div>
-					</header>
-					<div class="bsf-entry-content clear" itemprop="text">
-						<?php the_content(); ?>
+				<div id="post-<?php the_ID(); ?>" class="post-<?php the_ID(); ?> post type-chnangelogs status-publish format-standard chnangelogs_category">
+					<div class="bsf-changelog-post-wrapper">
+						<header class="entry-header">
+							<div class="pre-title" id="<?php echo ( sanitize_title( get_post_field( 'post_name', get_post() ) ) ); ?>">
+								<div class="img-name-date-section">
+								<div class="author-img-section">
+									<?php if ( get_avatar( get_the_author_meta('ID') ) ) {
+										echo get_avatar( get_the_author_meta('ID') );
+                        			} else { ?>
+                            			<img src="/images/no-image-default.jpg" />
+                        			<?php } ?>
+								</div>
+								<div class="author-name-date-section">
+									<div class="author-name"><?php the_author(); ?></div>
+									<div class="publish-date"><?php echo get_the_date(); ?></div>
+								</div>
+								</div>
+							</div>
+							<a href="#<?php echo ( sanitize_title( get_post_field( 'post_name', get_post() ) ) ); ?>"><?php echo $link_icon; ?><h2 class="entry-title"><?php the_title(); ?> </h2></a>
+						</header>
+						<?php
+						$img_pos = apply_filters( 'bsf_changelog_img_position_' . get_the_ID(), 'after' );
+						$img_pos_all = apply_filters( 'bsf_changelog_img_position_all', 'after' );
+						if ( ( 'before' === $img_pos || 'before' === $img_pos_all ) && has_post_thumbnail() ) { ?>
+							<div class="bsf-changelog-img <?php echo $img_class; ?>" style="margin-bottom: 16px;"><?php the_post_thumbnail( 'full' ); ?></div>
+						<?php }
+						do_action( 'bsf_changelog_before_content_' . get_the_ID() );
+						?>
+						<?php if ( has_excerpt() ) { ?>
+							<div class="bsf-entry-content content-closed clear" itemprop="text">
+							<?php the_excerpt(); ?>
+							</div>
+							<span class="see-more-text">Continue Reading...</span>
+						<?php } ?>
+						<?php $style = has_excerpt() ? 'style="display:none;"': ''; ?>
+						<div class="bsf-entry-content content-open clear" itemprop="text" <?php echo $style; ?>>
+							<?php the_content(); ?>
+						</div>
 					</div>
-					<?php edit_post_link( 'Edit' ); ?>
-				</article>
+					<?php
+					do_action( 'bsf_changelog_after_version_content', get_the_ID() );
+					do_action( 'bsf_changelog_after_content_' . get_the_ID() );
+					if ( ( 'after' === $img_pos || 'after' === $img_pos_all ) && ( 'before' !== $img_pos && 'before' !== $img_pos_all ) && has_post_thumbnail() ) { ?>
+						<div class="bsf-changelog-img <?php echo $img_class; ?>"><?php the_post_thumbnail( 'full' ); ?></div>
+					<?php }
+					?>
+				</div>
 				<?php
 			endwhile;
-			the_posts_pagination(
-				array(
-					'prev_text'          => '&laquo;<span class="screen-reader-text">' . __( 'Previous page', 'bsf-changelog' ) . '</span>',
-					'next_text'          => '<span class="screen-reader-text">' . __( 'Next page', 'bsf-changelog' ) . '</span>&raquo;',
-					'before_page_number' => '<span class="meta-nav screen-reader-text">' . __( 'Page', 'bsf-changelog' ) . ' </span>',
-				)
-			);
-
 		endif;
 		?>
 
 		</main><!-- #main -->
+		<div class='bsf-pagination'>
+		<?php the_posts_pagination(
+			array(
+				'prev_text'          => '&laquo;<span class="screen-reader-text">' . __( 'Previous page', 'bsf-changelog' ) . '</span>',
+				'next_text'          => '<span class="screen-reader-text">' . __( 'Next page', 'bsf-changelog' ) . '</span>&raquo;',
+			)
+		); ?>
+		</div>
+		<?php if ( isset( $bsf_changelog_scroll_pagination ) && '1' === $bsf_changelog_scroll_pagination || 'yes' === $bsf_changelog_scroll_pagination ) { ?>
+			<nav class="bsf-pagination-infinite">
+				<div class="bsf-loader">
+					<div class="bsf-loader-1"></div>
+					<div class="bsf-loader-2"></div>
+					<div class="bsf-loader-3"></div>
+				</div>
+			</nav>
+		<?php } ?>
 	</div><!-- #primary -->
 </div><!-- .wrap -->
 

--- a/includes/templates/add-category-meta.php
+++ b/includes/templates/add-category-meta.php
@@ -1,0 +1,11 @@
+<div class="form-field term-group">
+	<label>
+		<?php _e( 'Changelog Raw File URL', 'bsf-changelog' ); ?>
+	</label>
+	<p>
+		<input type="text" placeholder="https://raw.githubusercontent.com/brainstormforce/bsf-products/master/astra/changelog.txt" name="term_meta[changelog-file-url]" class="product-changelog-file-url" id="product-changelog-file-url" value=""/>
+	</p>
+	<p>
+		<em><?php _e( 'This URL will be use to redirect users when click on "More Details".', 'bsf-changelog' ); ?></em>
+	</p>
+</div>

--- a/includes/templates/edit-category-meta.php
+++ b/includes/templates/edit-category-meta.php
@@ -1,0 +1,11 @@
+<tr class="form-field term-group-wrap">
+	<th scope="row">
+		<label for="doc-changelog-file-url"><?php _e( 'Changelog Raw File URL', 'bsf-changelog' ); ?></label>
+	</th>
+	<td>
+		<input type="text" placeholder="https://raw.githubusercontent.com/brainstormforce/bsf-products/master/astra/changelog.txt" name="term_meta[changelog-file-url]" class="doc-changelog-file-url" id="doc-changelog-file-url" value="<?php echo esc_url( $changelog_file_url ); ?>"/>
+		<p class="description">
+			<?php _e( 'This URL will be use to redirect users when click on "More Details".', 'bsf-changelog' ); ?>
+		</p>
+	</td>
+</tr>

--- a/package.json
+++ b/package.json
@@ -2,10 +2,13 @@
   "name": "bsf-changelog",
   "version": "1.0.6",
   "main": "Gruntfile.js",
-  "author": "YOUR NAME HERE",
+  "author": "Brainstorm Force",
   "devDependencies": {
     "grunt": "^1.4.1",
     "grunt-wp-i18n": "^1.0.3",
-    "grunt-wp-readme-to-markdown": "^2.0.1"
+    "grunt-wp-readme-to-markdown": "^2.0.1",
+    "grunt-contrib-clean": "^2.0.0",
+    "grunt-contrib-compress": "^1.4.3",
+    "grunt-contrib-copy": "^1.0.0"
   }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pratikchaskar
 Tags: changelog, wpchangelog, products-changelog,
 Requires at least: 3.0
 Tested up to: 6.5
-Stable tag: 1.0.6
+Stable tag: 1.0.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## What
Replaces #30. Same change set, squashed into a single **signed** commit with `master` merged in (conflicts resolved).

## Why a new PR
The org ruleset on `master` requires verified signatures on every commit in a PR. #30 contains unsigned commits, so GitHub refuses the merge with any merge method. This branch carries one signed commit with a tree identical to the conflict-resolved `sub-versioning` branch.

## Changes (from #30)
- Sub-versioning: hierarchical changelog CPT, child posts render as collapsible sub-version list under the parent; option to expand by default
- Infinite scroll pagination (optional) with loader
- Redesigned archive/taxonomy cards: author avatar + name, publish date, version tag, product category pill, anchor-linked titles with optional paperclip icon
- Excerpt "Continue Reading" toggle; option to hide featured image when expanded
- Featured image position filters (`bsf_changelog_img_position_{ID}` / `_all`)
- Changelog Raw File URL option (global setting + per-product term meta)
- Archive slug changed to `whats-new`; admin list ordered by date DESC
- Grunt `release` task for building the plugin zip
- Fix: removed call to undefined `set_term_order()` that caused a fatal on Product term save
- Version bump 1.0.7, tested up to WP 6.5